### PR TITLE
restore ndindex docs

### DIFF
--- a/ndindex/README
+++ b/ndindex/README
@@ -1,0 +1,3 @@
+This is here to redirect the old ndindex links to the new ones at
+quansight-labs.github.io/ndindex (GitHub pages does not automatically redirect
+when a repo is moved).

--- a/ndindex/api.html
+++ b/ndindex/api.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/api.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/api.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/api.html">https://Quansight-Labs.github.io/ndindex/api.html</a>&hellip;</p>
+</body>
+</html>
+

--- a/ndindex/changelog.html
+++ b/ndindex/changelog.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/changelog.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/changelog.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/changelog.html">https://Quansight-Labs.github.io/ndindex/changelog.html</a>&hellip;</p>
+</body>
+</html>
+

--- a/ndindex/genindex.html
+++ b/ndindex/genindex.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/genindex.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/genindex.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/genindex.html">https://Quansight-Labs.github.io/ndindex/genindex.html</a>&hellip;</p>
+</body>
+</html>
+

--- a/ndindex/index.html
+++ b/ndindex/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/index.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/index.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/index.html">https://Quansight-Labs.github.io/ndindex/index.html</a>&hellip;</p>
+</body>
+</html>

--- a/ndindex/make_redirects.py
+++ b/ndindex/make_redirects.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+"""
+Automatically generate redirect pages.
+
+"""
+
+import os
+import sys
+import argparse
+import glob
+
+REDIRECT_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url={DOMAIN}/{SLUG}">
+    <link rel="canonical" href="{DOMAIN}/{SLUG}">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="{DOMAIN}/{SLUG}">{DOMAIN}/{SLUG}</a>&hellip;</p>
+</body>
+</html>
+
+"""
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "source",
+        action="store",
+        nargs=1,
+        )
+    p.add_argument(
+        "dest",
+        action="store",
+        nargs=1,
+        )
+    p.add_argument(
+        "domain",
+        action="store",
+        nargs=1,
+        )
+    args = p.parse_args()
+
+    source = args.source[0].rstrip('/')
+    dest = args.dest[0].rstrip('/')
+    domain = args.domain[0].rstrip('/')
+    if not domain.startswith('http'):
+        p.error("The domain should start with https://")
+
+    for path in glob.glob(source + '/**.html', recursive=True):
+        if '.git' in path:
+            continue
+        file = path[len(source) + 1:]
+        newpath = os.path.join(dest, file)
+        os.makedirs(os.path.split(newpath)[0], exist_ok=True)
+        # It must always be /, even on Windows
+        redirect = '/'.join(file.split(os.path.sep))
+        with open(os.path.join(newpath), 'w') as f:
+            f.write(REDIRECT_TEMPLATE.format(DOMAIN=domain, SLUG=redirect))
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ndindex/search.html
+++ b/ndindex/search.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/search.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/search.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/search.html">https://Quansight-Labs.github.io/ndindex/search.html</a>&hellip;</p>
+</body>
+</html>
+

--- a/ndindex/slices.html
+++ b/ndindex/slices.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/slices.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/slices.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/slices.html">https://Quansight-Labs.github.io/ndindex/slices.html</a>&hellip;</p>
+</body>
+</html>
+

--- a/ndindex/style-guide.html
+++ b/ndindex/style-guide.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/style-guide.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/style-guide.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/style-guide.html">https://Quansight-Labs.github.io/ndindex/style-guide.html</a>&hellip;</p>
+</body>
+</html>
+

--- a/ndindex/type-confusion.html
+++ b/ndindex/type-confusion.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf8">
+    <meta http-equiv="refresh" content="0; url=https://Quansight-Labs.github.io/ndindex/type-confusion.html">
+    <link rel="canonical" href="https://Quansight-Labs.github.io/ndindex/type-confusion.html">
+    <title>This page has moved</title>
+</head>
+<body>
+    <p>This page has moved. Redirecting you to <a href="https://Quansight-Labs.github.io/ndindex/type-confusion.html">https://Quansight-Labs.github.io/ndindex/type-confusion.html</a>&hellip;</p>
+</body>
+</html>
+


### PR DESCRIPTION
this pull restores @asmeurer's `ndindex` docs.

when we make changes to this site we'll to consider how to include documentation like this. 

are these docs generated from https://github.com/Quansight-Labs/ndindex ?